### PR TITLE
Fix a bug: ActiveModel::Validations:AssociatedValidator doesn't exist, should have been ActiveRecord

### DIFF
--- a/lib/caprese/record/associated_validator.rb
+++ b/lib/caprese/record/associated_validator.rb
@@ -27,7 +27,7 @@ module Caprese
     module ClassMethods
       def validates_associated(*attr_names)
         validates_with(
-          (Caprese::Record.caprese_style_errors ? Caprese::Record : ActiveModel::Validations)::AssociatedValidator,
+          (Caprese::Record.caprese_style_errors ? Caprese::Record : ActiveRecord::Validations)::AssociatedValidator,
           _merge_attributes(attr_names)
         )
       end


### PR DESCRIPTION
Whenever ActiveModel::Validations::AssociatedValidator was accessed, Caprese makes Rails crash.