### PR TITLE
Add note about use with Devise

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,18 @@ You should also look into the configuration for [ActiveModelSerializers](https:/
 
 Coming soon... :)
 
+### Using with Devise or other authentication
+
+If you use a `before_action` filter such as Devise's `authenticate_user!`, be sure to prepend it, like so:
+
+```ruby
+class Api::V1::User::ApiController < Caprese::Controller
+  prepend_before_action :authenticate_user!
+end
+```
+
+Otherwise, Caprese's `around_action :enable_caprese_style_errors` will run first, then the action will fail, causing Caprese Style Errors to stay enabled even for your non-Caprese controllers that show errors for Caprese models (such as login pages).
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. You can also run `bin/console` for an interactive prompt that will allow you to experiment.


### PR DESCRIPTION
Apparently, [intended Rails callback behavior](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/callbacks.rb#L74) is to run `before` and `around` callbacks (at least the part before the `yield` in whatever order they were defined in. Honestly, it makes sense to me that the order would be as follows:

```
before
around (before part)
action
around (after part)
after
```

But alas, that's not how it works, so this fix is necessary.