### PR TITLE
Fix error i18n pluralizer

### DIFF
--- a/lib/caprese/record/errors.rb
+++ b/lib/caprese/record/errors.rb
@@ -14,7 +14,7 @@ module Caprese
       def add(attribute, code = :invalid, options = {})
         options = options.dup
         options[:t] ||= {}
-        options[:t][:count] = options[:count]
+        options[:t][:count] ||= options[:count]
         options[:t][:value] ||= options[:value] ||
           if attribute != :base && @base.respond_to?(attribute)
             @base.send(:read_attribute_for_validation, attribute)

--- a/spec/dummy/config/locales/en.yml
+++ b/spec/dummy/config/locales/en.yml
@@ -25,6 +25,13 @@ en:
     v1:
       errors:
         models:
+          post:
+            title:
+              too_fluffy:
+                one:
+                  Title has one fluff, which is too much
+                other:
+                  Title has %{count} fluffs, which is way too much
           comment:
             rating:
               value:

--- a/spec/record_spec.rb
+++ b/spec/record_spec.rb
@@ -7,7 +7,8 @@ describe Caprese::Record, type: :model do
   after { Caprese::Record.caprese_style_errors = false }
 
   describe '#errors' do
-    before { record.errors.add(field) }
+    let(:options) { {} }
+    before { record.errors.add(field, :too_fluffy, options) }
 
     let(:error) { record.errors.to_a.first }
 
@@ -24,6 +25,22 @@ describe Caprese::Record, type: :model do
 
       it 'sets field title to model name' do
         expect(error.t[:field]).to eq('title')
+      end
+
+      context 'with pluralized value' do
+        context 'value 1' do
+          let(:options) { { t: { count: 1 } } }
+
+          subject { record.errors.full_messages.join }
+          it { is_expected.to eq 'Title has one fluff, which is too much'}
+        end
+
+        context 'value 5' do
+          let(:options) { { t: { count: 5 } } }
+
+          subject { record.errors.full_messages.join }
+          it { is_expected.to eq 'Title has 5 fluffs, which is way too much'}
+        end
       end
     end
   end


### PR DESCRIPTION
Previously, if an error was created using `errors.add :foo, t: { count: 123 }`, the `t[:count]` parameter was internally overwritten the `count` parameter, even if it's unset. This is not backwards compatible.
Fix it so that this only happens if no `t[:count]` is provided in the call.
